### PR TITLE
Bump up to v0.2.0 in kubeps

### DIFF
--- a/Formula/kubeps.rb
+++ b/Formula/kubeps.rb
@@ -1,5 +1,5 @@
 class Kubeps < Formula
-  VERSION = "v0.1.0"
+  VERSION = "v0.2.0"
 
   desc ""
   homepage "https://github.com/koudaiii/kubeps"

--- a/Formula/kubeps.rb
+++ b/Formula/kubeps.rb
@@ -4,7 +4,7 @@ class Kubeps < Formula
   desc ""
   homepage "https://github.com/koudaiii/kubeps"
   url "https://github.com/koudaiii/kubeps/releases/download/#{VERSION}/kubeps-#{VERSION}-darwin-amd64.tar.gz"
-  sha256 "71e1ea00bcd514a78ff4250d520282385c930a3f8f79d76579e239dd2d03889c"
+  sha256 "5cb83fd7f36aea407441c5f1bab3cc1d98ea996aaff6da043a535ee6e088a2f8"
 
   def install
     bin.install "kubeps"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ brew tap koudaiii/tools
 
 | Name | Description | Version |
 |------|-------------|---------|
-| [kubeps](https://github.com/koudaiii/kubeps) | Get Container status and image tag in Kubernetes  | [v0.1.0](https://github.com/koudaiii/kubeps/releases/tag/v0.1.0) |
+| [kubeps](https://github.com/koudaiii/kubeps) | Get Container status and image tag in Kubernetes  | [v0.2.0](https://github.com/koudaiii/kubeps/releases/tag/v0.2.0) |
 | [dockerepos](https://github.com/koudaiii/dockerepos) | Manage repository in Quay | [v0.1.0](https://github.com/koudaiii/dockerepos/releases/tag/v0.1.0) |
 
 


### PR DESCRIPTION
## REF
https://github.com/koudaiii/kubeps/releases/tag/v0.2.0

## WHY

Bump up to v0.2.0 in kubeps
