### PR TITLE
Bump up to v0.5.0 qucli

### DIFF
--- a/Formula/qucli.rb
+++ b/Formula/qucli.rb
@@ -5,7 +5,7 @@ class Qucli < Formula
   homepage "https://github.com/koudaiii/qucli"
   url "https://github.com/koudaiii/qucli/releases/download/v#{VERSION}/qucli-v#{VERSION}-darwin-amd64.tar.gz"
   version VERSION
-  sha256 "c60265dcbfe06a1438c27f3fe7884c7a681f86a2fc53c025f70c73cf3e58a00e"
+  sha256 "a169019e4fffbaa2dd940c1cc422dc5900a672cd3514110302dc4f6b551f3c2c"
 
   def install
     bin.install "qucli"

--- a/Formula/qucli.rb
+++ b/Formula/qucli.rb
@@ -1,5 +1,5 @@
 class Qucli < Formula
-  VERSION = "0.4.0".freeze
+  VERSION = "0.5.0".freeze
 
   desc "Manage repositories in Quay.io"
   homepage "https://github.com/koudaiii/qucli"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ brew tap koudaiii/tools
 | Name | Description | Version |
 |------|-------------|---------|
 | [kubeps](https://github.com/koudaiii/kubeps) | Get Container status and image tag in Kubernetes  | [v0.2.3](https://github.com/koudaiii/kubeps/releases/tag/v0.2.3) |
-| [qucli](https://github.com/koudaiii/qucli) | Manage repository in Quay | [v0.4.0](https://github.com/koudaiii/qucli/releases/tag/v0.4.0) |
+| [qucli](https://github.com/koudaiii/qucli) | Manage repository in Quay | [v0.5.0](https://github.com/koudaiii/qucli/releases/tag/v0.5.0) |
 | [sltd](https://github.com/koudaiii/sltd) | Tag ELB from service label in kubernetes cluster for Datadog monitoring. | [v0.2.0](https://github.com/koudaiii/sltd/releases/tag/v0.2.0) |
 
 ## How to Release

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ $ brew tap koudaiii/tools
 
 - Create branch
 - Set up version
-- `$ shasum -a 256  ~/Download/hoge.zip`
-- Check `$ script/check-sha256sum https://github.com/koudaiii/#{TOOL}/releases/download/#{VERSION}/#{TOOL}-#{VERSION}-darwin-amd64.tar.gz`
+- Check `$ curl -L https://github.com/koudaiii/#{TOOL}/releases/download/#{VERSION}/#{TOOL}-#{VERSION}-darwin-amd64.tar.gz > file.tar.gz && shasum -a 256 file.tar.gz`
 
 ## Author
 


### PR DESCRIPTION
## REF

## WHY

Upgrade qucli. https://github.com/koudaiii/qucli/releases/tag/v0.5.0 https://github.com/koudaiii/qucli/pull/26
https://github.com/koudaiii/qucli/issues/22

## WHAT

- checked

```
$ curl -L https://github.com/koudaiii/qucli/releases/download/v0.5.0/qucli-v0.5.0-darwin-amd64.tar.gz > file.tar.gz && shasum -a 256 file.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   622    0   622    0     0    585      0 --:--:--  0:00:01 --:--:--   585
100 1809k  100 1809k    0     0   292k      0  0:00:06  0:00:06 --:--:--  417k
a169019e4fffbaa2dd940c1cc422dc5900a672cd3514110302dc4f6b551f3c2c  file.tar.gz
```