### PR TITLE
Bump up to v0.6.2 qucli

### DIFF
--- a/Formula/qucli.rb
+++ b/Formula/qucli.rb
@@ -1,11 +1,11 @@
 class Qucli < Formula
-  VERSION = "0.5.0".freeze
+  VERSION = "0.6.2".freeze
 
   desc "Manage repositories in Quay.io"
   homepage "https://github.com/koudaiii/qucli"
   url "https://github.com/koudaiii/qucli/releases/download/v#{VERSION}/qucli-v#{VERSION}-darwin-amd64.tar.gz"
   version VERSION
-  sha256 "a169019e4fffbaa2dd940c1cc422dc5900a672cd3514110302dc4f6b551f3c2c"
+  sha256 "a62a4968cc8bfe69b6ffdae1b12b94dbfed0a63367590c302250640ae1826848"
 
   def install
     bin.install "qucli"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ brew tap koudaiii/tools
 | Name | Description | Version |
 |------|-------------|---------|
 | [kubeps](https://github.com/koudaiii/kubeps) | Get Container status and image tag in Kubernetes  | [v0.2.3](https://github.com/koudaiii/kubeps/releases/tag/v0.2.3) |
-| [qucli](https://github.com/koudaiii/qucli) | Manage repository in Quay | [v0.5.0](https://github.com/koudaiii/qucli/releases/tag/v0.5.0) |
+| [qucli](https://github.com/koudaiii/qucli) | Manage repository in Quay | [v0.6.2](https://github.com/koudaiii/qucli/releases/tag/v0.6.2) |
 | [sltd](https://github.com/koudaiii/sltd) | Tag ELB from service label in kubernetes cluster for Datadog monitoring. | [v0.2.0](https://github.com/koudaiii/sltd/releases/tag/v0.2.0) |
 
 ## How to Release


### PR DESCRIPTION
## WHY

Release https://github.com/koudaiii/qucli/releases/tag/v0.6.2 https://github.com/koudaiii/qucli/issues/23

## WHAT

homebrew update