### PR TITLE
Fix sha

### DIFF
--- a/Formula/qucli.rb
+++ b/Formula/qucli.rb
@@ -5,7 +5,7 @@ class Qucli < Formula
   homepage "https://github.com/koudaiii/qucli"
   url "https://github.com/koudaiii/qucli/releases/download/v#{VERSION}/qucli-v#{VERSION}-darwin-amd64.tar.gz"
   version VERSION
-  sha256 "a62a4968cc8bfe69b6ffdae1b12b94dbfed0a63367590c302250640ae1826848"
+  sha256 "2f397bbb9bf423a6a73c5929fcb9e41c4e9a1c23260ba09f0a43ac73128475d0"
 
   def install
     bin.install "qucli"


### PR DESCRIPTION
## WHY

```
$ brew upgrade qucli
==> Upgrading 1 outdated package, with result:
koudaiii/tools/qucli 0.6.2
==> Upgrading koudaiii/tools/qucli 
==> Downloading https://github.com/koudaiii/qucli/releases/download/v0.6.2/qucli-v0.6.2-darwin-amd64.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/78281484/a10a43f4-b37f-11e7-9946-f2688b2623b8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20171017
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: a62a4968cc8bfe69b6ffdae1b12b94dbfed0a63367590c302250640ae1826848
Actual: 2f397bbb9bf423a6a73c5929fcb9e41c4e9a1c23260ba09f0a43ac73128475d0
Archive: /Users/koudaiii/Library/Caches/Homebrew/qucli-0.6.2.tar.gz
To retry an incomplete download, remove the file above.
```

## WHAT

fix it