### PR TITLE
Bump up to v0.6.3 qucli

### DIFF
--- a/Formula/qucli.rb
+++ b/Formula/qucli.rb
@@ -1,11 +1,11 @@
 class Qucli < Formula
-  VERSION = "0.6.2".freeze
+  VERSION = "0.6.3".freeze
 
   desc "Manage repositories in Quay.io"
   homepage "https://github.com/koudaiii/qucli"
   url "https://github.com/koudaiii/qucli/releases/download/v#{VERSION}/qucli-v#{VERSION}-darwin-amd64.tar.gz"
   version VERSION
-  sha256 "2f397bbb9bf423a6a73c5929fcb9e41c4e9a1c23260ba09f0a43ac73128475d0"
+  sha256 "75e3391f2cbd89a4a92f5901b52ad69a103cf3e35bab6f45f422bd579985ed2f"
 
   def install
     bin.install "qucli"


### PR DESCRIPTION
## WHY

https://github.com/koudaiii/qucli/releases/tag/v0.6.3
Bump up to v0.6.3 qucli

